### PR TITLE
added support for label translation domain

### DIFF
--- a/src/Limenius/Liform/Transformer/AbstractTransformer.php
+++ b/src/Limenius/Liform/Transformer/AbstractTransformer.php
@@ -116,10 +116,11 @@ abstract class AbstractTransformer
      */
     protected function addLabel($form, $schema)
     {
+        $translationDomain = $form->getConfig()->getOption('translation_domain');
         if ($label = $form->getConfig()->getOption('label')) {
-            $schema['title'] = $this->translator->trans($label);
+            $schema['title'] = $this->translator->trans($label, [], $translationDomain);
         } else {
-            $schema['title'] = $this->translator->trans($form->getName());
+            $schema['title'] = $this->translator->trans($form->getName(), [], $translationDomain);
         }
 
         return $schema;


### PR DESCRIPTION
i created issue in liform bundle repo : https://github.com/Limenius/LiformBundle/issues/4
this is the PR for solve it :) this had check of form use a translation doomain (like FOSUser do) and use it to translate form label ! :)