### PR TITLE
added support for redux form errors without BC break

### DIFF
--- a/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
@@ -38,6 +38,7 @@ class FormErrorNormalizer implements NormalizerInterface
             'code' => isset($context['status_code']) ? $context['status_code'] : null,
             'message' => 'Validation Failed',
             'errors' => $this->convertFormToArray($object),
+            'redux_form_errors' => $this->convertFormToReduxFormErrorsArray($object),
         ];
     }
 
@@ -48,6 +49,36 @@ class FormErrorNormalizer implements NormalizerInterface
     {
         return $data instanceof FormInterface && $data->isSubmitted() && !$data->isValid();
     }
+
+    /**
+     * same as convertFormtoArray but fit with redux form intented data      
+     */
+    private function convertFormToReduxFormErrorsArray(FormInterface $data){
+        
+        $form = $errors = [];
+        foreach ($data->getErrors() as $error) {
+            $errors[] = $this->getErrorMessage($error);
+        }
+        if (!empty($errors)) {
+            $form = $errors;
+        }
+        foreach ($data->all() as $child) {
+            if ($child instanceof FormInterface) {
+                $result = $this->convertFormToReduxFormErrorsArray($child);
+                if($result){
+                    $form[$child->getName()] = $this->convertFormToReduxFormErrorsArray($child);
+                }
+                
+            }
+        }
+        
+        if(empty($form)){
+            return false;
+        }
+        return $form;
+        
+    }
+
 
     /**
      * This code has been taken from JMSSerializer.


### PR DESCRIPTION
this will add "redux_form_errors" support, then, could be used after ajax submission with
throw new SubmissionError(  data.errors.redux_form_errors )
this fix : https://github.com/Limenius/Liform/issues/19