### PR TITLE
Correct ChoiceTransformer schema

### DIFF
--- a/src/Limenius/Liform/Transformer/ChoiceTransformer.php
+++ b/src/Limenius/Liform/Transformer/ChoiceTransformer.php
@@ -45,7 +45,7 @@ class ChoiceTransformer extends AbstractTransformer
                     'minItems' => $this->isRequired($form) ? 1 : 0,
                 ],
                 'uniqueItems' => true,
-                'type' => 'array',
+                'type' => 'object',
             ];
 
             if (count($choices)) {

--- a/src/Limenius/Liform/Transformer/ChoiceTransformer.php
+++ b/src/Limenius/Liform/Transformer/ChoiceTransformer.php
@@ -42,19 +42,24 @@ class ChoiceTransformer extends AbstractTransformer
             $schema = [
                 'items' => [
                     'type' => 'string',
-                    'enum' => $choices,
-                    'enum_titles' => $titles,
                     'minItems' => $this->isRequired($form) ? 1 : 0,
                 ],
                 'uniqueItems' => true,
                 'type' => 'array',
             ];
+
+            if (count($choices)) {
+                $schema['items']['enum'] = $choices;
+                $schema['items']['enum_titles'] = $titles;
+            }
         } else {
             $schema = [
-                'enum' => $choices,
-                'enum_titles' => $titles,
                 'type' => 'string',
             ];
+            if (count($choices)) {
+                $schema['enum'] = $choices;
+                $schema['enum_titles'] = $titles;
+            }
         }
 
         $schema = $this->addCommonSpecs($form, $schema, $extensions, $widget);

--- a/src/Limenius/Liform/Transformer/ChoiceTransformer.php
+++ b/src/Limenius/Liform/Transformer/ChoiceTransformer.php
@@ -43,7 +43,7 @@ class ChoiceTransformer extends AbstractTransformer
                 'items' => [
                     'type' => 'string',
                     'enum' => $choices,
-                    'liform' => ['enum_titles' => $titles],
+                    'enum_titles' => $titles,
                     'minItems' => $this->isRequired($form) ? 1 : 0,
                 ],
                 'uniqueItems' => true,

--- a/tests/Limenius/Liform/Tests/Transformer/ChoiceTransformerTest.php
+++ b/tests/Limenius/Liform/Tests/Transformer/ChoiceTransformerTest.php
@@ -75,4 +75,42 @@ class ChoiceTransformerTest extends LiformTestCase
         $this->assertEquals(['RED', 'BLUE', 'GREEN'], $transformed['properties']['favoriteColours']['items']['enum_titles']);
         $this->assertEquals(['Red', 'Blue', 'Green'], $transformed['properties']['favoriteColours']['items']['enum']);
     }
+
+    /**
+     * testSingleEmptyChoice - Add a ChoiceType with no options, ensure that the schema does not have enum or enum_titles
+     * as an enum must not be an empty array
+     *
+     * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2
+     */
+    public function testSingleEmptyChoice()
+    {
+        $form = $this->factory->create(FormType::class)
+            ->add(
+                'favoriteColours',
+                Type\ChoiceType::class,
+                [
+                    'choices' => []
+                ]
+            );
+
+        $resolver = new Resolver();
+        $resolver->setTransformer('choice', new Transformer\ChoiceTransformer($this->translator, null));
+        $transformer = new CompoundTransformer($this->translator, null, $resolver);
+        $transformed = $transformer->transform($form);
+
+        $this->assertArrayNotHasKey('enum', $transformed['properties']['favoriteColours']);
+        $this->assertArrayNotHasKey('enum_titles', $transformed['properties']['favoriteColours']);
+        $this->assertEquals('string', $transformed['properties']['favoriteColours']['type']);
+    }
+
+    /**
+     * testMultipleEmptyChoice - Add a ChoiceType with no options, ensure that the items do not have enum or enum_titles
+     * as an enum must not be an empty array.
+     *
+     * @see http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.1.2
+     */
+    public function testMultipleEmptyChoice()
+    {
+        $this->markTestIncomplete();
+    }
 }

--- a/tests/Limenius/Liform/Tests/Transformer/ChoiceTransformerTest.php
+++ b/tests/Limenius/Liform/Tests/Transformer/ChoiceTransformerTest.php
@@ -41,4 +41,38 @@ class ChoiceTransformerTest extends LiformTestCase
         $this->assertArrayHasKey('enum', $transformed['properties']['firstName']);
         $this->assertEquals(['A', 'B'], $transformed['properties']['firstName']['enum']);
     }
+
+    /**
+     * testMultipleChoice - Ensure that the schema produced matches what the ChoiceType would expect
+     */
+    public function testMultipleChoice()
+    {
+        $form = $this->factory->create(FormType::class)
+            ->add(
+                'favoriteColours',
+                Type\ChoiceType::class,
+                [
+                    'multiple' => true,
+                    'choices' => [
+                        'RED' => 'Red',
+                        'BLUE' => 'Blue',
+                        'GREEN' => 'Green'
+                    ]
+                ]
+            );
+
+
+        $this->translator
+            ->method('trans')
+            ->will($this->returnCallback(function ($str) {
+                return $str;
+            }));
+
+        $resolver = new Resolver();
+        $resolver->setTransformer('choice', new Transformer\ChoiceTransformer($this->translator, null));
+        $transformer = new CompoundTransformer($this->translator, null, $resolver);
+        $transformed = $transformer->transform($form);
+        $this->assertEquals(['RED', 'BLUE', 'GREEN'], $transformed['properties']['favoriteColours']['items']['enum_titles']);
+        $this->assertEquals(['Red', 'Blue', 'Green'], $transformed['properties']['favoriteColours']['items']['enum']);
+    }
 }


### PR DESCRIPTION
Hi there,

We've just started using Liform in our Symfony application to generate our React forms and it looks awesome.

I've just come across this small issue whereby the `ChoiceWidget` doesn't render the labels of a multiple choice because the labels/titles aren't where they should be.

I've added a test, hopefully it explains what is expected - see https://github.com/Limenius/liform-react/blob/master/src/themes/bootstrap3/ChoiceWidget.js#L13 for an example of what the ChoiceWidget expects.

There isn't a `CONTRIBUTING.md` file so please let me know if you want me to change any formatting of the file, etc.

Cheers