### PR TITLE
Serialise CollectionType as array not StdObject

### DIFF
--- a/src/Limenius/Liform/Form/Extension/CollectionTypeExtension.php
+++ b/src/Limenius/Liform/Form/Extension/CollectionTypeExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace Limenius\Liform\Form\Extension;
+
+
+use Limenius\Liform\Serializer\Normalizer\FormViewNormalizer;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+/**
+ * This Extension exists to add a var to the CollectionType so that the FormViewNormalizer can serialise the data
+ * ready for the redux-form ArrayWidget.
+ */
+class CollectionTypeExtension extends AbstractTypeExtension
+{
+
+    /**
+     * @param FormView      $view
+     * @param FormInterface $form
+     * @param array         $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        parent::buildView($view, $form, $options);
+
+        $view->vars[FormViewNormalizer::NORMALIZATION_STRATEGY] = FormViewNormalizer::CHILDREN_AS_ARRAY;
+    }
+
+    /**
+     * Returns the name of the type being extended.
+     *
+     * @return string The name of the type being extended
+     */
+    public function getExtendedType()
+    {
+        return CollectionType::class;
+    }
+}

--- a/src/Limenius/Liform/Serializer/Normalizer/FormViewNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/FormViewNormalizer.php
@@ -1,12 +1,9 @@
 <?php
+
 namespace Limenius\Liform\Serializer\Normalizer;
 
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Translation\TranslatorInterface;
-
-use Limenius\LiformBundle\Liform\FormUtil;
 
 /**
  * Class: FormViewNormalizer
@@ -30,9 +27,9 @@ class FormViewNormalizer implements NormalizerInterface
      */
     public function normalize($form, $format = null, array $context = [])
     {
-        if (!empty($form->children)) {
-            $useArray = $this->useArrayForChildren($form);
+        $useArray = $this->useArrayForChildren($form);
 
+        if (!empty($form->children)) {
             $serializedForm = $useArray ? array() : (object) array();
 
             foreach ($form->children as $name => $child) {
@@ -58,7 +55,14 @@ class FormViewNormalizer implements NormalizerInterface
                 return $form->vars['checked'];
             }
 
-            return $form->vars['value'];
+            $value = $form->vars['value'];
+
+            //If this is an iterable it's likely that the widget is expecting an array, not stdObject
+            if ($value instanceof \Traversable && iterator_count($value) === 0 && $useArray) {
+                return array();
+            }
+
+            return $value;
         }
     }
 


### PR DESCRIPTION
Hey,

I've just come across an issue with the normalised CollectionType serialisation. It seems that as it stands the Liform `FormViewNormalizer` serialises everything as an object, including elements that we'd expect to render using an [FieldArray](https://redux-form.com/7.1.2/docs/api/fieldarray.md/)

The FieldArray expects data to be in an array:
```json
{
  "form": {
    "myArray": [
      {
        "id": 1
      },
      {
        "id": 2
      }
    ]
  }
}
```

However it receives:
```json
{
  "form": {
    "myArray": {
      "0": {
        "id": 1
      },
      "1": {
        "id": 2
      }
    }
  }
}
```

You can see that if you look in the redux debugging toolkit.

I believe I have come up with a good solution by using a `FormViewExtension`.

Look forward to your feedback

Thanks!