### PR TITLE
Avoid unknown field error during initial values normalization when csrf_protection is true

### DIFF
--- a/src/Limenius/Liform/Serializer/Normalizer/InitialValuesNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/InitialValuesNormalizer.php
@@ -61,7 +61,12 @@ class InitialValuesNormalizer implements NormalizerInterface
                 if (empty($child->children) && ($child->vars['value'] === null || $child->vars['value'] === '')) {
                     continue;
                 }
-                $data->{$name} = $this->getValues($form[$name], $child);
+
+                // Avoid unknown field error when csrf_protection is true
+                // CSRF token should be extracted another way
+                if ($form->has($name)) {
+                    $data->{$name} = $this->getValues($form->get($name), $child);
+                }
             }
 
             return $data;


### PR DESCRIPTION
InitialValuesNormalizer returned Unknown field '...' error when csrf_protection was on.
The CSRF token value is not serialized with this commit. It should be extracted from the form manually.