### PR TITLE
Fix deprecation warning in Symfony 4.2

### DIFF
--- a/src/Limenius/Liform/Form/Extension/AddLiformExtension.php
+++ b/src/Limenius/Liform/Form/Extension/AddLiformExtension.php
@@ -33,6 +33,14 @@ class AddLiformExtension extends AbstractTypeExtension
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public static function getExtendedTypes(): iterable
+    {
+        return [FormType::class];
+    }
+
+    /**
      * Add the liform option
      *
      * @param OptionsResolver $resolver

--- a/src/Limenius/Liform/Form/Extension/AddLiformExtension.php
+++ b/src/Limenius/Liform/Form/Extension/AddLiformExtension.php
@@ -33,9 +33,11 @@ class AddLiformExtension extends AbstractTypeExtension
     }
 
     /**
-     * {@inheritdoc}
+     * Gets the extended types.
+     *
+     * @return iterable
      */
-    public static function getExtendedTypes(): iterable
+    public static function getExtendedTypes()
     {
         return [FormType::class];
     }


### PR DESCRIPTION
This addresses `Not implementing the static getExtendedTypes() method in Limenius\Liform\Form\Extension\AddLiformExtension when implementing the Symfony\Component\Form\FormTypeExtensionInterface is deprecated since Symfony 4.2. The method will be added to the interface in 5.0.`