### PR TITLE
Symfony 5 uplift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
 
 before_install:
     - composer self-update

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ in the *installation chapter* of the Composer documentation.
 
 > Liform follows the PSR-4 convention names for its classes, which means you can easily integrate `Liform` classes loading in your own autoloader.
 
+#### Note
+`symfony/form ^5.0` broke backwards compatibility on some abstract functions we use. If you need to function with
+earlier versions, you need to use Liform v0.15 or earlier:
+
+    $ composer require limenius/liform "^0.15"
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,13 @@
       "symfony/contracts": "^2.1"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.5",
-        "escapestudios/symfony2-coding-standard": "^2.9",
-        "wimg/php-compatibility": "^7.0",
-        "phpunit/phpunit": "^9.1"
+        "squizlabs/php_codesniffer": "^3.5",
+        "escapestudios/symfony2-coding-standard": "^3.0",
+        "phpunit/phpunit": "^9.1",
+        "phpcompatibility/php-compatibility": "^9.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2"
     },
     "scripts": {
-        "default-scripts": [
-            "rm -rf vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; cp -rp vendor/wimg/php-compatibility vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility"
-        ],
         "post-install-cmd": [
             "@default-scripts"
         ],

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,17 @@
         }
     },
     "require": {
-      "symfony/form": "~2.8|~3.0|^4.0",
-      "symfony/translation": "~2.3|~3.0|^4.0",
-      "symfony/serializer": "~2.8|~3.0|^4.0"
+      "php": "^7.2.5",
+      "symfony/form": "^5.0",
+      "symfony/translation": "^5.0",
+      "symfony/serializer": "^5.0",
+      "symfony/contracts": "^2.1"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",
         "escapestudios/symfony2-coding-standard": "^2.9",
-        "wimg/php-compatibility": "^7.0"
+        "wimg/php-compatibility": "^7.0",
+        "phpunit/phpunit": "^9.1"
     },
     "scripts": {
         "default-scripts": [

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5",
         "escapestudios/symfony2-coding-standard": "^3.0",
-        "phpunit/phpunit": "^9.1",
+        "phpunit/phpunit": "^8.0",
         "phpcompatibility/php-compatibility": "^9.3",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2"
     },

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -6,9 +6,6 @@
     <exclude-pattern>Resources/</exclude-pattern>
     <exclude-pattern>tests/</exclude-pattern>
 
-    <rule ref="vendor/escapestudios/symfony2-coding-standard/Symfony2"/>
-    <rule ref="vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility" />
-
     <config name="testVersion" value="5.5-7.0"/>
 
     <rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd">

--- a/src/Limenius/Liform/Form/Extension/AddLiformExtension.php
+++ b/src/Limenius/Liform/Form/Extension/AddLiformExtension.php
@@ -37,7 +37,7 @@ class AddLiformExtension extends AbstractTypeExtension
      *
      * @return iterable
      */
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return [FormType::class];
     }

--- a/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
@@ -14,7 +14,7 @@ namespace Limenius\Liform\Serializer\Normalizer;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Normalizes invalid Form instances.

--- a/src/Limenius/Liform/Transformer/AbstractTransformer.php
+++ b/src/Limenius/Liform/Transformer/AbstractTransformer.php
@@ -13,7 +13,7 @@ namespace Limenius\Liform\Transformer;
 
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeGuesserInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Nacho Martín <nacho@limenius.com>

--- a/src/Limenius/Liform/Transformer/ArrayTransformer.php
+++ b/src/Limenius/Liform/Transformer/ArrayTransformer.php
@@ -15,7 +15,7 @@ use Limenius\Liform\Exception\TransformerException;
 use Limenius\Liform\ResolverInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeGuesserInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Nacho Martín <nacho@limenius.com>

--- a/src/Limenius/Liform/Transformer/CompoundTransformer.php
+++ b/src/Limenius/Liform/Transformer/CompoundTransformer.php
@@ -15,7 +15,7 @@ use Limenius\Liform\FormUtil;
 use Limenius\Liform\ResolverInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeGuesserInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Nacho Martín <nacho@limenius.com>

--- a/tests/Limenius/Liform/Tests/LiformTestCase.php
+++ b/tests/Limenius/Liform/Tests/LiformTestCase.php
@@ -13,8 +13,9 @@ namespace Limenius\Liform\Tests;
 
 use Limenius\Liform\Form\Extension\AddLiformExtension;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Forms;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  *
@@ -34,7 +35,7 @@ class LiformTestCase extends TestCase
      */
     protected $translator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $ext = new AddLiformExtension();
         $this->factory = Forms::createFormFactoryBuilder()
@@ -42,6 +43,6 @@ class LiformTestCase extends TestCase
             ->addTypeExtensions([$ext])
             ->getFormFactory();
 
-        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->translator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
     }
 }

--- a/tests/Limenius/Liform/Tests/ResolverTest.php
+++ b/tests/Limenius/Liform/Tests/ResolverTest.php
@@ -11,12 +11,11 @@
 
 namespace Limenius\Liform\Tests;
 
-use Limenius\Liform\Resolver;
 use Limenius\Liform\Exception\TransformerException;
+use Limenius\Liform\Resolver;
 use Limenius\Liform\Transformer\StringTransformer;
-use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Test\TypeTestCase;
 
 /**
  * @author Nacho Martín <nacho@limenius.com>
@@ -31,11 +30,10 @@ class ResolverTest extends TypeTestCase
         $this->assertInstanceOf(Resolver::class, $resolver);
     }
 
-    /**
-     * @expectedException \Limenius\Liform\Exception\TransformerException
-     */
     public function testCannotResolve()
     {
+        $this->expectException(TransformerException::class);
+
         $resolver = new Resolver();
         $form = $this->factory->create(TextType::class);
         $this->assertArrayHasKey('transformer', $resolver->resolve($form));

--- a/tests/Limenius/Liform/Tests/Serializer/InitialValuesNormalizerTest.php
+++ b/tests/Limenius/Liform/Tests/Serializer/InitialValuesNormalizerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Limenius\Liform\Tests\Normalizer;
+namespace Limenius\Liform\Tests\Serializer;
 
 use Limenius\Liform\Serializer\Normalizer\InitialValuesNormalizer;
 use Limenius\Liform\Tests\LiformTestCase;

--- a/tests/Limenius/Liform/Tests/Transformer/ChoiceTransformerTest.php
+++ b/tests/Limenius/Liform/Tests/Transformer/ChoiceTransformerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Limenius\Liform\Tests\Liform\Transformer;
+namespace Limenius\Liform\Tests\Transformer;
 
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\Extension\Core\Type\FormType;

--- a/tests/Limenius/Liform/Tests/Transformer/CommonTransformerTest.php
+++ b/tests/Limenius/Liform/Tests/Transformer/CommonTransformerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Limenius\Liform\Tests\Liform\Transformer;
+namespace Limenius\Liform\Tests\Transformer;
 
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;

--- a/tests/Limenius/Liform/Tests/Transformer/CompoundTransformerTest.php
+++ b/tests/Limenius/Liform/Tests/Transformer/CompoundTransformerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Limenius\Liform\Tests\Liform\Transformer;
+namespace Limenius\Liform\Tests\Transformer;
 
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcher;

--- a/tests/Limenius/Liform/Tests/Transformer/NumberTransformerTest.php
+++ b/tests/Limenius/Liform/Tests/Transformer/NumberTransformerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Limenius\Liform\Tests\Liform\Transformer;
+namespace Limenius\Liform\Tests\Transformer;
 
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;

--- a/tests/Limenius/Liform/Tests/Transformer/StringTransformerTest.php
+++ b/tests/Limenius/Liform/Tests/Transformer/StringTransformerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Limenius\Liform\Tests\Liform\Transformer;
+namespace Limenius\Liform\Tests\Transformer;
 
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;


### PR DESCRIPTION
v0.15 and earlier are not compatible with symfony 5. 

Unfortunately, `symfony/form 5` broke bc when adding `interable` as return type for `Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes` (which liform implements in `AddLiformExtension`). Trying to get around this is more trouble than it's worth, so this PR drops compatibility for symfony 4 and earlier.

This also required bumping php version from 7.1 to 7.2 and a number of other changes (eg substituting abandoned libs etc):

### Note: this will require a new release of liform (v0.16)

## Changes
  * symfony components 5 are now required
  * php 7.2.5+ required
  * update README with note on which version of liform to use when either of the two bullet points above are false
  * update to latest phpunit for php 7.2 (v8.x), plus required changes to make it work
  * add missing dependencies to composer.json, like `symfony /contracts` - if liform's code references them (eg on a `use` statement) then they're dependencies and should be on composer explicitly
  * simplify phpcs setup with `dealerdirect/phpcodesniffer-composer-installer` which ensures rulesets in deps are automatically added to php cs
  * fix namespacing on some tests not being PSR-4 compliant based on their paths. These would've stopped loading for people running composer 2
  * tweak travis to check on current supported php versions (7.2/3/4)