### PR TITLE
Use symfony/translation-contracts instead of symfony/contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "symfony/form": "^4.4|^5.0",
     "symfony/translation": "^4.4|^5.0",
     "symfony/serializer": "^4.4|^5.0",
-    "symfony/contracts": "^1.0|^2.1"
+    "symfony/translation-contracts": "^1.0|^2.1|^3.0"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",


### PR DESCRIPTION
`symfony/contracts` is a package replacing all Symfony contracts at once. The recommendation is to depend on the individual packages instead, which allow projects to install only the contracts they need (and potentially to have different versions of each contract package).

I'm also adding support for `symfony/translation-contracts` v3 because the BC breaks in it are only for implementors of the interface, not for consumers of the interface (and this package only consumes the interface).