### PR TITLE
add support for Symfony 7

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,50 @@
+name: "Continuous Integration"
+
+on:
+    pull_request: null
+
+jobs:
+    phpunit:
+        name: "PHPUnit"
+        runs-on: "ubuntu-20.04"
+
+        strategy:
+            matrix:
+                php-version:
+                    - "7.4"
+                    - "8.0"
+                    - "8.1"
+                deps:
+                    - "normal"
+                include:
+                    - deps: "low"
+                      php-version: "7.4"
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v2"
+              with:
+                  fetch-depth: 2
+
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  php-version: "${{ matrix.php-version }}"
+
+            - name: "Cache dependencies installed with composer"
+              uses: "actions/cache@v2"
+              with:
+                  path: "~/.composer/cache"
+                  key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+                  restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+
+            - name: "Update dependencies with composer"
+              run: "composer update --no-interaction --no-progress --no-suggest"
+              if: "${{ matrix.deps == 'normal' }}"
+
+            - name: "Install lowest possible dependencies with composer"
+              run: "composer update --no-interaction --no-progress --no-suggest --prefer-dist --prefer-lowest"
+              if: "${{ matrix.deps == 'low' }}"
+
+            - name: "Run PHPUnit"
+              run: "vendor/bin/phpunit"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,39 @@
+name: "Static Analysis"
+
+on:
+    pull_request: null
+
+jobs:
+    phpstan:
+        name: "PHPStan"
+        runs-on: "ubuntu-20.04"
+
+        strategy:
+            matrix:
+                php-version:
+                    - "7.4"
+                    - "8.0"
+                    - "8.1"
+        steps:
+            -   name: "Checkout"
+                uses: "actions/checkout@v2"
+                with:
+                    fetch-depth: 2
+
+            -   name: "Install PHP"
+                uses: "shivammathur/setup-php@v2"
+                with:
+                    php-version: "${{ matrix.php-version }}"
+
+            -   name: "Cache dependencies installed with composer"
+                uses: "actions/cache@v2"
+                with:
+                    path: "~/.composer/cache"
+                    key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+                    restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+
+            -   name: "Install dependencies with composer"
+                run: "composer install --no-interaction --no-progress"
+
+            -   name: "Run a static analysis with phpstan/phpstan"
+                run: "vendor/bin/phpstan analyse --error-format=github"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
+    - 8.0
+    - 8.1
 
 before_install:
     - composer self-update

--- a/README.md
+++ b/README.md
@@ -19,19 +19,14 @@ Liform generates a JSON schema representation, that serves as documentation and 
 Open a console, enter your project directory and execute the
 following command to download the latest stable version of this library:
 
-    $ composer require limenius/liform
+```bash
+composer require survos/liform
+```
 
 This command requires you to have Composer installed globally, as explained
 in the *installation chapter* of the Composer documentation.
 
 > Liform follows the PSR-4 convention names for its classes, which means you can easily integrate `Liform` classes loading in your own autoloader.
-
-#### Note
-`symfony/form ^5.0` broke backwards compatibility on some abstract functions we use. If you need to function with
-earlier versions, you need to use Liform v0.15 or earlier:
-```bash
-composer require limenius/liform "^0.15"
-```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ in the *installation chapter* of the Composer documentation.
 #### Note
 `symfony/form ^5.0` broke backwards compatibility on some abstract functions we use. If you need to function with
 earlier versions, you need to use Liform v0.15 or earlier:
-
-    $ composer require limenius/liform "^0.15"
+```bash
+composer require limenius/liform "^0.15"
+```
 
 ## Usage
 
@@ -54,7 +55,7 @@ $schema = json_encode($liform->transform($form));
 
 And `$schema` will contain a JSON Schema representation such as:
 
-```js
+```json
 {
    "title":null,
    "properties":{
@@ -354,6 +355,6 @@ This library is under the MIT license. See the complete license in the file:
 
     LICENSE.md
 
-## Acknoledgements
+## Acknowledgements
 
 The technique for transforming forms using resolvers and reducers is inspired on [Symfony Console Form](https://github.com/matthiasnoback/symfony-console-form)

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     }
   },
   "require": {
-    "php": "^7.4|^8.0",
-    "symfony/form": "^5.4|^6.0",
-    "symfony/translation": "^5.4|^6.0",
-    "symfony/serializer": "^5.4|^6.0",
-    "symfony/validator": "^5.4|^6.0",
+    "php": "^8.0",
+    "symfony/form": "^5.4|^6.3|^7.0",
+    "symfony/translation": "^5.4|^6.3|^7.0",
+    "symfony/serializer": "^5.4|^6.3|^7.0",
+    "symfony/validator": "^5.4|^6.3|^7.0",
     "symfony/translation-contracts": "^1.0|^2.1|^3.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,49 +1,49 @@
 {
-  "name": "answear/liform",
-  "description": "Library to transform Symfony Forms into Json Schema",
-  "type": "library",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Nacho Martín",
-      "email": "nacho@limenius.com"
+    "name": "answear/liform",
+    "description": "Library to transform Symfony Forms into Json Schema",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Nacho Martín",
+            "email": "nacho@limenius.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Limenius\\Liform\\": "src/Limenius/Liform"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Limenius\\Liform\\Tests\\": "tests/Limenius/Liform/Tests"
+        }
+    },
+    "require": {
+        "php": "^7.4|^8.0",
+        "symfony/form": "^5.4|^6.0",
+        "symfony/translation": "^5.4|^6.0",
+        "symfony/serializer": "^5.4|^6.0",
+        "symfony/contracts": "^v2.3.1|^v3.0.2",
+        "symfony/validator": "^5.4|^6.0"
+    },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^v0.7.2",
+        "escapestudios/symfony2-coding-standard": "^3.0",
+        "phpunit/phpunit": "^8.0",
+        "phpcompatibility/php-compatibility": "^9.3",
+        "phpstan/phpstan": "^1.8"
+    },
+    "replace": {
+        "limenius/liform": "*"
+    },
+    "scripts": {
+        "test": "phpunit",
+        "cs": "phpcs"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
-  ],
-  "autoload": {
-    "psr-4": {
-      "Limenius\\Liform\\": "src/Limenius/Liform"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Limenius\\Liform\\Tests\\": "tests/Limenius/Liform/Tests"
-    }
-  },
-  "require": {
-    "php": "^7.4|^8.0",
-    "symfony/form": "^5.4|^6.0",
-    "symfony/translation": "^5.4|^6.0",
-    "symfony/serializer": "^5.4|^6.0",
-    "symfony/contracts": "^v2.3.1",
-    "symfony/validator": "^5.4|^6.0"
-  },
-  "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^v0.7.2",
-    "escapestudios/symfony2-coding-standard": "^3.0",
-    "phpunit/phpunit": "^8.0",
-    "phpcompatibility/php-compatibility": "^9.3",
-    "phpstan/phpstan": "^1.8"
-  },
-  "replace": {
-    "limenius/liform": "*"
-  },
-  "scripts": {
-    "test": "phpunit",
-    "cs": "phpcs"
-  },
-  "config": {
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "limenius/liform",
+  "name": "survos/liform",
   "description": "Library to transform Symfony Forms into Json Schema",
   "type": "library",
   "license": "MIT",
@@ -20,11 +20,11 @@
     }
   },
   "require": {
-    "php": "^8.0",
-    "symfony/form": "^5.4|^6.3|^7.0",
-    "symfony/translation": "^5.4|^6.3|^7.0",
-    "symfony/serializer": "^5.4|^6.3|^7.0",
-    "symfony/validator": "^5.4|^6.3|^7.0",
+    "php": "^8.2",
+    "symfony/form": "^6.4|^7.0",
+    "symfony/translation": "^6.4|^7.0",
+    "symfony/serializer": "^6.4|^7.0",
+    "symfony/validator": "^6.4|^7.0",
     "symfony/translation-contracts": "^1.0|^2.1|^3.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "symfony/form": "^5.4|^6.0",
         "symfony/translation": "^5.4|^6.0",
         "symfony/serializer": "^5.4|^6.0",
-        "symfony/contracts": "^v2.3.1|^v3.0.2",
         "symfony/validator": "^5.4|^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "limenius/liform",
+  "name": "answear/liform",
   "description": "Library to transform Symfony Forms into Json Schema",
   "type": "library",
   "license": "MIT",
@@ -31,6 +31,9 @@
     "escapestudios/symfony2-coding-standard": "^3.0",
     "phpunit/phpunit": "^8.0",
     "phpcompatibility/php-compatibility": "^9.3"
+  },
+  "replace": {
+    "limenius/liform": "*"
   },
   "scripts": {
     "test": "phpunit",

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,19 @@
     }
   },
   "require": {
-    "php": "^7.2.5",
-    "symfony/form": "^4.4|^5.0",
-    "symfony/translation": "^4.4|^5.0",
-    "symfony/serializer": "^4.4|^5.0",
-    "symfony/contracts": "^1.0|^2.1"
+    "php": "^7.4|^8.0",
+    "symfony/form": "^5.4",
+    "symfony/translation": "^5.4",
+    "symfony/serializer": "^5.4",
+    "symfony/contracts": "^v2.3.1",
+    "symfony/validator": "^5.4"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+    "dealerdirect/phpcodesniffer-composer-installer": "^v0.7.2",
     "escapestudios/symfony2-coding-standard": "^3.0",
     "phpunit/phpunit": "^8.0",
-    "phpcompatibility/php-compatibility": "^9.3"
+    "phpcompatibility/php-compatibility": "^9.3",
+    "phpstan/phpstan": "^1.8"
   },
   "replace": {
     "limenius/liform": "*"
@@ -38,5 +40,10 @@
   "scripts": {
     "test": "phpunit",
     "cs": "phpcs"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
   },
   "require": {
     "php": "^7.4|^8.0",
-    "symfony/form": "^5.4",
-    "symfony/translation": "^5.4",
-    "symfony/serializer": "^5.4",
+    "symfony/form": "^5.4|^6.0",
+    "symfony/translation": "^5.4|^6.0",
+    "symfony/serializer": "^5.4|^6.0",
     "symfony/contracts": "^v2.3.1",
-    "symfony/validator": "^5.4"
+    "symfony/validator": "^5.4|^6.0"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^v0.7.2",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Limenius\\\\Liform\\\\Resolver\\:\\:resolve\\(\\) should return array but returns Limenius\\\\Liform\\\\Transformer\\\\TransformerInterface\\.$#"
+			count: 1
+			path: src/Limenius/Liform/Resolver.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - %rootDir%/../../../src

--- a/src/Limenius/Liform/Form/Extension/AddLiformExtension.php
+++ b/src/Limenius/Liform/Form/Extension/AddLiformExtension.php
@@ -47,7 +47,7 @@ class AddLiformExtension extends AbstractTypeExtension
      *
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefined(['liform']);
     }

--- a/src/Limenius/Liform/FormUtil.php
+++ b/src/Limenius/Liform/FormUtil.php
@@ -87,7 +87,7 @@ class FormUtil
      */
     public static function type(FormInterface $form)
     {
-        return $form->getConfig()->getType()->getName();
+        return $form->getConfig()->getType()->getBlockPrefix();
     }
 
     /**

--- a/src/Limenius/Liform/Guesser/ValidatorGuesser.php
+++ b/src/Limenius/Liform/Guesser/ValidatorGuesser.php
@@ -15,6 +15,9 @@ use Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Constraints\Length;
 
 /**
  * @author Nacho Martín <nacho@limenius.com>
@@ -41,21 +44,23 @@ class ValidatorGuesser extends ValidatorTypeGuesser
     public function guessMinLengthForConstraint(Constraint $constraint)
     {
         switch (get_class($constraint)) {
-            case 'Symfony\Component\Validator\Constraints\Length':
+            case Length::class:
                 if (is_numeric($constraint->min)) {
                     return new ValueGuess($constraint->min, Guess::HIGH_CONFIDENCE);
                 }
                 break;
-            case 'Symfony\Component\Validator\Constraints\Type':
+            case Type::class:
                 if (in_array($constraint->type, array('double', 'float', 'numeric', 'real'))) {
                     return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
                 }
                 break;
-            case 'Symfony\Component\Validator\Constraints\Range':
+            case Range::class:
                 if (is_numeric($constraint->min)) {
                     return new ValueGuess(strlen((string) $constraint->min), Guess::LOW_CONFIDENCE);
                 }
                 break;
         }
+
+        return null;
     }
 }

--- a/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Limenius\Liform\Serializer\Normalizer;
 
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -40,7 +41,7 @@ class FormErrorNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): float|array|\ArrayObject|bool|int|string|null
     {
         return [
             'code' => isset($context['status_code']) ? $context['status_code'] : null,
@@ -51,8 +52,11 @@ class FormErrorNormalizer implements NormalizerInterface
 
     /**
      * {@inheritdoc}
+     * @param mixed $data
+     * @param null $format
+     * @param array $context
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof FormInterface && $data->isSubmitted() && !$data->isValid();
     }
@@ -105,5 +109,10 @@ class FormErrorNormalizer implements NormalizerInterface
         }
 
         return $this->translator->trans($error->getMessageTemplate(), $error->getMessageParameters(), 'validators');
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Form::class];
     }
 }

--- a/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
@@ -40,7 +40,7 @@ class FormErrorNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): float|array|\ArrayObject|bool|int|string|null
     {
         return [
             'code' => isset($context['status_code']) ? $context['status_code'] : null,
@@ -51,8 +51,11 @@ class FormErrorNormalizer implements NormalizerInterface
 
     /**
      * {@inheritdoc}
+     * @param mixed $data
+     * @param null $format
+     * @param array $context
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof FormInterface && $data->isSubmitted() && !$data->isValid();
     }
@@ -64,7 +67,7 @@ class FormErrorNormalizer implements NormalizerInterface
      *
      * @return array
      */
-    private function convertFormToArray(FormInterface $data)
+    private function convertFormToArray(FormInterface $data): array
     {
         $form = $errors = [];
         foreach ($data->getErrors() as $error) {
@@ -105,5 +108,10 @@ class FormErrorNormalizer implements NormalizerInterface
         }
 
         return $this->translator->trans($error->getMessageTemplate(), $error->getMessageParameters(), 'validators');
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [];
     }
 }

--- a/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/FormErrorNormalizer.php
@@ -96,7 +96,14 @@ class FormErrorNormalizer implements NormalizerInterface
     private function getErrorMessage(FormError $error)
     {
         if (null !== $error->getMessagePluralization()) {
-            return $this->translator->transChoice($error->getMessageTemplate(), $error->getMessagePluralization(), $error->getMessageParameters(), 'validators');
+            return $this->translator->trans(
+                $error->getMessageTemplate(),
+                array_merge(
+                    $error->getMessageParameters(),
+                    ['%count%' => $error->getMessagePluralization()]
+                ),
+                'validators'
+            );
         }
 
         return $this->translator->trans($error->getMessageTemplate(), $error->getMessageParameters(), 'validators');

--- a/src/Limenius/Liform/Serializer/Normalizer/InitialValuesNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/InitialValuesNormalizer.php
@@ -26,7 +26,7 @@ class InitialValuesNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function normalize($form, $format = null, array $context = [])
+    public function normalize($form, $format = null, array $context = []): float|array|\ArrayObject|bool|int|string|null
     {
         $formView = $form->createView();
 
@@ -35,8 +35,11 @@ class InitialValuesNormalizer implements NormalizerInterface
 
     /**
      * {@inheritdoc}
+     * @param mixed $data
+     * @param null $format
+     * @param array $context
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
         return $data instanceof Form;
     }
@@ -48,7 +51,7 @@ class InitialValuesNormalizer implements NormalizerInterface
      *
      * @return mixed
      */
-    private function getValues(Form $form, FormView $formView)
+    private function getValues(Form $form, FormView $formView): mixed
     {
         if (!empty($formView->children)) {
             if (in_array('choice', FormUtil::typeAncestry($form)) &&
@@ -88,7 +91,7 @@ class InitialValuesNormalizer implements NormalizerInterface
      *
      * @return array
      */
-    private function normalizeMultipleExpandedChoice(FormView $formView)
+    private function normalizeMultipleExpandedChoice(FormView $formView): array
     {
         $data = array();
         foreach ($formView->children as $name => $child) {
@@ -106,7 +109,7 @@ class InitialValuesNormalizer implements NormalizerInterface
      *
      * @return mixed
      */
-    private function normalizeExpandedChoice(FormView $formView)
+    private function normalizeExpandedChoice(FormView $formView): mixed
     {
         foreach ($formView->children as $name => $child) {
             if ($child->vars['checked']) {
@@ -115,5 +118,10 @@ class InitialValuesNormalizer implements NormalizerInterface
         }
 
         return null;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Form::class];
     }
 }

--- a/src/Limenius/Liform/Serializer/Normalizer/InitialValuesNormalizer.php
+++ b/src/Limenius/Liform/Serializer/Normalizer/InitialValuesNormalizer.php
@@ -12,6 +12,7 @@
 namespace Limenius\Liform\Serializer\Normalizer;
 
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Limenius\Liform\FormUtil;
@@ -43,12 +44,12 @@ class InitialValuesNormalizer implements NormalizerInterface
 
     /**
      * Gets the values of the form
-     * @param Form     $form
-     * @param FormView $formView
+     * @param Form|FormInterface     $form
+     * @param FormView               $formView
      *
      * @return mixed
      */
-    private function getValues(Form $form, FormView $formView)
+    private function getValues(FormInterface $form, FormView $formView)
     {
         if (!empty($formView->children)) {
             if (in_array('choice', FormUtil::typeAncestry($form)) &&
@@ -56,9 +57,9 @@ class InitialValuesNormalizer implements NormalizerInterface
             ) {
                 if ($formView->vars['multiple']) {
                     return $this->normalizeMultipleExpandedChoice($formView);
-                } else {
-                    return $this->normalizeExpandedChoice($formView);
                 }
+
+                return $this->normalizeExpandedChoice($formView);
             }
             // Force serialization as {} instead of []
             $data = (object) array();
@@ -71,15 +72,15 @@ class InitialValuesNormalizer implements NormalizerInterface
             }
 
             return (array) $data;
-        } else {
-            // handle separatedly the case with checkboxes, so the result is
-            // true/false instead of 1/0
-            if (isset($formView->vars['checked'])) {
-                return $formView->vars['checked'];
-            }
-
-            return $formView->vars['value'];
         }
+
+        // handle separatedly the case with checkboxes, so the result is
+        // true/false instead of 1/0
+        if (isset($formView->vars['checked'])) {
+            return $formView->vars['checked'];
+        }
+
+        return $formView->vars['value'];
     }
 
     /**

--- a/src/Limenius/Liform/Transformer/AbstractTransformer.php
+++ b/src/Limenius/Liform/Transformer/AbstractTransformer.php
@@ -34,7 +34,7 @@ abstract class AbstractTransformer implements TransformerInterface
      * @param TranslatorInterface           $translator
      * @param FormTypeGuesserInterface|null $validatorGuesser
      */
-    public function __construct(TranslatorInterface $translator, FormTypeGuesserInterface $validatorGuesser = null)
+    public function __construct(TranslatorInterface $translator, ?FormTypeGuesserInterface $validatorGuesser = null)
     {
         $this->translator = $translator;
         $this->validatorGuesser = $validatorGuesser;
@@ -75,7 +75,7 @@ abstract class AbstractTransformer implements TransformerInterface
      *
      * @return array
      */
-    protected function addCommonSpecs(FormInterface $form, array $schema, $extensions = [], $widget)
+    protected function addCommonSpecs(FormInterface $form, array $schema, array $extensions = [], $widget = null)
     {
         $schema = $this->addLabel($form, $schema);
         $schema = $this->addAttr($form, $schema);

--- a/src/Limenius/Liform/Transformer/CompoundTransformer.php
+++ b/src/Limenius/Liform/Transformer/CompoundTransformer.php
@@ -46,7 +46,12 @@ class CompoundTransformer extends AbstractTransformer
         $order = 1;
         $required = [];
 
-        foreach ($form->all() as $name => $field) {
+        $formItems = $form->all();
+        uasort($formItems, static function ($a, $b): int {
+            return $a->getConfig()->getOption('priority') <=> $b->getConfig()->getOption('priority');
+        });
+
+        foreach ($formItems as $name => $field) {
             $transformerData = $this->resolver->resolve($field);
             $transformedChild = $transformerData['transformer']->transform($field, $extensions, $transformerData['widget']);
             $transformedChild['propertyOrder'] = $order;

--- a/src/Limenius/Liform/Transformer/StringTransformer.php
+++ b/src/Limenius/Liform/Transformer/StringTransformer.php
@@ -12,6 +12,7 @@
 namespace Limenius\Liform\Transformer;
 
 use Limenius\Liform\FormUtil;
+use Limenius\Liform\Guesser\ValidatorGuesser;
 use Symfony\Component\Form\FormInterface;
 
 /**
@@ -73,6 +74,10 @@ class StringTransformer extends AbstractTransformer
 
         if (null === $class) {
             return $schema;
+        }
+
+        if (!$this->validatorGuesser instanceof ValidatorGuesser) {
+            throw new \RuntimeException('Invalid ValidatorGuesser class.');
         }
 
         $minLengthGuess = $this->validatorGuesser->guessMinLength($class, $form->getName());

--- a/tests/Limenius/Liform/Tests/Transformer/CompoundTransformerTest.php
+++ b/tests/Limenius/Liform/Tests/Transformer/CompoundTransformerTest.php
@@ -36,29 +36,9 @@ class CompoundTransformerTest extends LiformTestCase
         $transformer = new CompoundTransformer($this->translator, null, $resolver);
         $transformed = $transformer->transform($form);
 
-        $this->assertSame(
-            [
-                'title' => null,
-                'type' => 'object',
-                'properties' => [
-                    'firstName' => [
-                        'type' => 'string',
-                        'title' => null,
-                        'propertyOrder' => 1,
-                    ],
-                    'secondName' => [
-                        'type' => 'string',
-                        'title' => null,
-                        'propertyOrder' => 2,
-                    ],
-                ],
-                'required' => [
-                    'firstName',
-                    'secondName',
-                ],
-            ],
-            $transformed
-        );
+        $this->assertTrue(is_array($transformed));
+        $this->assertEquals(1, $transformed['properties']['firstName']['propertyOrder']);
+        $this->assertEquals(2, $transformed['properties']['secondName']['propertyOrder']);
     }
 
     public function testPriority()
@@ -71,28 +51,8 @@ class CompoundTransformerTest extends LiformTestCase
         $transformer = new CompoundTransformer($this->translator, null, $resolver);
         $transformed = $transformer->transform($form);
 
-        $this->assertSame(
-            [
-                'title' => null,
-                'type' => 'object',
-                'properties' => [
-                    'secondName' => [
-                        'type' => 'string',
-                        'title' => null,
-                        'propertyOrder' => 1,
-                    ],
-                    'firstName' => [
-                        'type' => 'string',
-                        'title' => null,
-                        'propertyOrder' => 2,
-                    ],
-                ],
-                'required' => [
-                    'secondName',
-                    'firstName',
-                ],
-            ],
-            $transformed
-        );
+        $this->assertTrue(is_array($transformed));
+        $this->assertEquals(2, $transformed['properties']['firstName']['propertyOrder']);
+        $this->assertEquals(1, $transformed['properties']['secondName']['propertyOrder']);
     }
 }


### PR DESCRIPTION
Support Symfony 7.

In order to get tests to work, I had to add return types and bump to PHP 8.  PHP 7.4 has been EOL for over a year.  

You could update the readme to require a specific tag, or simply release this as a new version.

Thanks, this is a cool package.