### PR TITLE
Fix return type for isRequired to match Symfony Form return type

### DIFF
--- a/src/Limenius/Liform/Transformer/AbstractTransformer.php
+++ b/src/Limenius/Liform/Transformer/AbstractTransformer.php
@@ -28,7 +28,7 @@ abstract class AbstractTransformer implements TransformerInterface
     {
     }
 
-    public function isRequired(FormInterface $form): bool
+    public function isRequired(FormInterface $form): ?bool
     {
         return $form->getConfig()->getOption('required');
     }


### PR DESCRIPTION
Fix for https://github.com/Limenius/Liform/issues/79